### PR TITLE
/issue/icon-arrow-in-mobile-view

### DIFF
--- a/src/assets/styles/elements/_icon.scss
+++ b/src/assets/styles/elements/_icon.scss
@@ -1,8 +1,8 @@
 ///
 /// ICONS
 ///============================================================================
-$base-arrow-width: 8px;
-$base-arrow-height: 12px;
+$base-arrow-width: 0.5rem;
+$base-arrow-height: 0.75rem;
 
 .icon-arrow {
   display: inline-block;


### PR DESCRIPTION
There is still a problem !!!
Icon size doesn't correspond to font size.